### PR TITLE
fix bug in ea8d7ec

### DIFF
--- a/src/pypeflow/controller.py
+++ b/src/pypeflow/controller.py
@@ -26,7 +26,7 @@
 PypeController: This module provides the PypeWorkflow that controlls how a workflow is excuted.
 
 """
-
+import sys
 import datetime
 import multiprocessing
 import threading 


### PR DESCRIPTION
Failed to `import sys` for flush during shutdown.

This only affects shutdown on Exception/KeyboardInterrupt, but it can be annoying.